### PR TITLE
Fix caching of MAUI workloads in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -91,9 +91,8 @@ jobs:
             ${{ env.DOTNET_ROOT }}/packs
             ${{ env.DOTNET_ROOT }}/sdk-manifests
             ${{ env.DOTNET_ROOT }}/toolResolverCache
-          key: ${{ runner.os }}-maui-${{ env.DOTNET_VERSION }}-${{ hashFiles('**/*.csproj') }}
+          key: ${{ runner.os }}-maui-${{ env.DOTNET_VERSION }}
           restore-keys: |
-            ${{ runner.os }}-maui-${{ env.DOTNET_VERSION }}-
             ${{ runner.os }}-maui-
 
       - name: Install MAUI workloads


### PR DESCRIPTION
Closes #74:
- #74.

## What was done?

Changed MAUI workload caching key to not include hash of `.csproj` files.